### PR TITLE
chore(ci): add last fm key to ci

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,7 +8,7 @@ import Loading from './containers/Loading/Loading';
 
 const dev = true;
 export const authenticated = !!dev;
-export const API_KEY = process.env.API_KEY || 'local_test_key';
+export const API_KEY = process.env.LAST_FM_API_KEY || 'local_test_key';
 
 // Creating new route
 // 1) new Async-component


### PR DESCRIPTION
## Description:

The ci-setup currently fails because of the lack of a lastfm API key. 

This PR can be merged, once the API-Key is actually on circleci.